### PR TITLE
bugfix: zig bindings: specify `getFunc()` callconv(.C)

### DIFF
--- a/tools/genbinding.cpp
+++ b/tools/genbinding.cpp
@@ -585,7 +585,7 @@ pub fn init(plugin_getapi: *fn(name: [*:0]const u8) callconv(.C) ?*anyopaque) !v
   @setEvalBranchQuota(0x1000);
   @setRuntimeSafety(false);
 
-  const getFunc: ?*fn(v: [*:0]const u8, n: [*:0]const u8) *anyopaque =
+  const getFunc: ?*fn(v: [*:0]const u8, n: [*:0]const u8) callconv(.C) *anyopaque =
     @ptrCast(plugin_getapi("ImGui__getapi"));
   getError = @ptrCast(plugin_getapi("ImGui__geterr"));
 


### PR DESCRIPTION
Small fix for C callconv.

In init(), getFunc needs to have the C callconv. Wasn’t a problem in zig 0.13, but it causes the 0.14 version to mis-compile:

```zig
pub const api_version = "0.9.3";

const API = struct {}; // bunch of fn ptrs here.
var api: API = undefined;

pub fn init(plugin_getapi: *fn (fn_name: [*:0]const u8) callconv(.C) ?*anyopaque) !void {
  
  // load getFunc 
  const getFunc: ?*fn (api_version: [*:0]const u8, fn_name: [*:0]const u8) *anyopaque =
      @alignCast(@ptrCast(plugin_getapi("ImGui__getapi")));

  if (getFunc == null ) return error.ImGui;

  // iterate the function declarations to get the API’s fn ptrs
  inline for (@typeInfo(API).@"struct".fields) |field| {
    // ERROR: ImGui__getapi: version number is empty
    const func_ptr = getFunc.?(api_version, field.name);

    @field(api, field.name) = @alignCast(@ptrCast(func_ptr));
  }
}
```